### PR TITLE
Fix topbar button width consistency on tablet

### DIFF
--- a/src/main/resources/static/css/darkmode.css
+++ b/src/main/resources/static/css/darkmode.css
@@ -1458,6 +1458,13 @@ body.is-loading [data-ui-action='true'] {
   }
 }
 
+@media (min-width: 992px) and (max-width: 1199px) {
+  .topbar-actions > .toolbar-link,
+  .topbar-actions .dropdown > .toolbar-link {
+    min-width: 188px;
+  }
+}
+
 @media (max-width: 991px) {
   .app-shell {
     width: min(100%, calc(100% - 24px));
@@ -1484,6 +1491,10 @@ body.is-loading [data-ui-action='true'] {
 
   .topbar-actions .dropdown,
   .topbar-actions .dropdown > .toolbar-link {
+    width: 100%;
+  }
+
+  .topbar-actions > .toolbar-link {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary\n- make topbar action buttons consistent in tablet widths\n- ensure direct license link matches theme/language control width behavior\n\n## Changes\n- add min-width: 188px for topbar action controls in 992px-1199px\n- add width: 100% for direct topbar link in <=991px\n\n## Scope\n- only src/main/resources/static/css/darkmode.css\n